### PR TITLE
Modification pour le support de matériel de Homewizard P1

### DIFF
--- a/core/class/SmartMeterP1.class.php
+++ b/core/class/SmartMeterP1.class.php
@@ -209,10 +209,14 @@ class SmartMeterP1 extends eqLogic {
 					"72.7.0",	// voltage 3
 					"31.7.0",	// intensity 1
 					"51.7.0",	// intensity 1
-					"71.7.0"	// intensity 1
+					"71.7.0",	// intensity 1
+					"21.7.0",	// Power 1
+					"41.7.0",	// Power 2
+					"61.7.0",	// Power 3
 				];
 				$fullregex = '/\d\-\d:(\d+\.\d+\.\d+)\((\d+\.\d{1,3})\*([VAkWh]+){1,3}\)/';
 				$coderegex = '/\d\-\d:(\d+\.\d+\.\d+)\((.*)\)/';
+				$coderegex2 = '/\d\-\d:(\d+\.\d+\.\d+)\((.*)\)\((\d+\.\d{1,3})\*([VAkWh]+){1,3}\)/';
 				$results = [];
 
 				if ($flagHomewizard) {
@@ -239,6 +243,21 @@ class SmartMeterP1 extends eqLogic {
 							$results[$current_code] = $value;
 						} else {
 							//log::add(__CLASS__, 'debug', "Unknown code {$current_code}");
+						}
+					} elseif (preg_match($coderegex2, $data, $matches) === 1) {
+						$current_code = $matches[1];
+						$c_date = $matches[2];
+						$current_value = $matches[3];
+
+						switch ($current_code) {
+							case '1.6.0':
+								$this->checkAndUpdateCmd($current_code, $current_value);
+								$current_date = substr($c_date, 4, 2) . '/' . substr($c_date, 2, 2) . '/' . substr($c_date, 0, 2) . '  ' . substr($c_date, 6, 2) . ':' . substr($c_date, 8, 2) . ':' . substr($c_date, 10, 2);
+								$this->checkAndUpdateCmd($current_code . 'd', $current_date);
+								break;
+							default:
+								//log::add(__CLASS__, 'debug', "additional unused data(2): {$current_code}={$current_data}");
+								break;
 						}
 					} elseif (preg_match($coderegex, $data, $matches) === 1) {
 						$current_code = $matches[1];

--- a/core/config/p1.json
+++ b/core/config/p1.json
@@ -13,6 +13,9 @@
                 "dashboard": "line",
                 "mobile": "line"
             },
+            "configuration": {
+                "historizeRound": 2
+            },
             "initialValue": 0
         },
         {
@@ -27,6 +30,9 @@
             "template": {
                 "dashboard": "line",
                 "mobile": "line"
+            },
+            "configuration": {
+                "historizeRound": 2
             },
             "initialValue": 0
         },
@@ -43,6 +49,9 @@
                 "dashboard": "line",
                 "mobile": "line"
             },
+            "configuration": {
+                "historizeRound": 2
+            },
             "initialValue": 0
         },
         {
@@ -57,6 +66,9 @@
             "template": {
                 "dashboard": "line",
                 "mobile": "line"
+            },
+            "configuration": {
+                "historizeRound": 2
             },
             "initialValue": 0
         },
@@ -73,6 +85,9 @@
                 "dashboard": "tile",
                 "mobile": "line"
             },
+            "configuration": {
+                "historizeRound": 2
+            },
             "initialValue": 0
         },
         {
@@ -87,6 +102,9 @@
             "template": {
                 "dashboard": "line",
                 "mobile": "line"
+            },
+            "configuration": {
+                "historizeRound": 2
             },
             "initialValue": 0
         },
@@ -103,6 +121,9 @@
                 "dashboard": "line",
                 "mobile": "line"
             },
+            "configuration": {
+                "historizeRound": 2
+            },
             "initialValue": 0
         },
         {
@@ -116,6 +137,9 @@
             "template": {
                 "dashboard": "tile",
                 "mobile": "line"
+            },
+            "configuration": {
+                "historizeRound": 2
             },
             "initialValue": 0
         },
@@ -131,6 +155,9 @@
                 "dashboard": "line",
                 "mobile": "line"
             },
+            "configuration": {
+                "historizeRound": 2
+            },
             "initialValue": 0
         },
         {
@@ -144,6 +171,9 @@
             "template": {
                 "dashboard": "line",
                 "mobile": "line"
+            },
+            "configuration": {
+                "historizeRound": 2
             },
             "initialValue": 0
         },
@@ -319,6 +349,81 @@
                 "mobile": "line"
             },
             "initialValue": 1
+        },
+        {
+            "logicalId": "21.7.0",
+            "name": "Puissance phase 1",
+            "type": "info",
+            "subtype": "numeric",
+            "generic_type": "POWER",
+            "isVisible": 1,
+            "isHistorized": 1,
+            "unite": "W",
+            "template": {
+                "dashboard": "line",
+                "mobile": "line"
+            },
+            "initialValue": 0
+        },
+        {
+            "logicalId": "41.7.0",
+            "name": "Puissance phase 2",
+            "type": "info",
+            "subtype": "numeric",
+            "generic_type": "POWER",
+            "isVisible": 1,
+            "isHistorized": 1,
+            "unite": "W",
+            "template": {
+                "dashboard": "line",
+                "mobile": "line"
+            },
+            "initialValue": 0
+        },
+        {
+            "logicalId": "61.7.0",
+            "name": "Puissance phase 3",
+            "type": "info",
+            "subtype": "numeric",
+            "generic_type": "POWER",
+            "isVisible": 1,
+            "isHistorized": 1,
+            "unite": "W",
+            "template": {
+                "dashboard": "line",
+                "mobile": "line"
+            },
+            "initialValue": 0
+        },
+        {
+            "logicalId": "1.6.0",
+            "name": "Puissance max",
+            "type": "info",
+            "subtype": "numeric",
+            "generic_type": "POWER",
+            "isVisible": 1,
+            "isHistorized": 0,
+            "unite": "kW",
+            "template": {
+                "dashboard": "line",
+                "mobile": "line"
+            },
+            "configuration": {
+                "historizeRound": 2
+            },
+            "initialValue": 0
+        },
+        {
+            "logicalId": "1.6.0d",
+            "name": "Puissance max (Date)",
+            "type": "info",
+            "subtype": "string",
+            "isVisible": 1,
+            "isHistorized": 0,
+            "template": {
+                "dashboard": "line",
+                "mobile": "line"
+            }
         }
-    ]
+   ]
 }

--- a/desktop/php/SmartMeterP1.php
+++ b/desktop/php/SmartMeterP1.php
@@ -136,6 +136,11 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                     </div>
                                 </div>
 
+                                <div class="form-group">
+                                    <label class="col-sm-3 control-label">{{Homewizard P1}}</label>
+                                    <div class="col-sm-1" style="width:20px">
+                                    <label class="checkbox-inline" style="vertical-align:top;"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="flagHomewizard"/></label>
+                                </div>
 
                             </div>
                             <div class="col-lg-4">


### PR DESCRIPTION
Ajout d'une option de configuration pour basculer en mode Homewizard.
Dans la class, modification de la fonction RefreshP1 pour traiter soit les mesaages originaux soit ceux en provenance de Homewizard.
Afin de limiter les modifications du code, la lecture de lignes en mode original sont mise en array comme c'est le cas en Homewizard.
L'array est ensuite traitée par un foreach.

Ajout des infos de puissance par phase (3) et la puissance max utilisée avec la date
Arrondi à deux décimales pour les valeurs injection et prélèvement.
